### PR TITLE
Fix for "Undefined variable: source"

### DIFF
--- a/classes/Models/Base.php
+++ b/classes/Models/Base.php
@@ -521,6 +521,7 @@ abstract class Base extends Eloquent
                 $source = DB::raw('CONCAT('.implode('," ",',$attributes).')');
                 break;
             case 'sqlite':
+            case 'pgsql':
                 $source = DB::raw(implode(' || ',$attributes));
                 break;
         }


### PR DESCRIPTION
With postgres as database driver you will see a ajax error message " Server request failed".

The error behind this generic message is:

```
ErrorException in Base.php line 530:
Undefined variable: source
```

This occurs only when using postgres.


STRs:

1. Use the predefined admin models (Tags, News ...) and make it available in the admin
2. Create some news
3. Create a new tag
4. Inside the tag edit view, you have on the right the listing for "News & Events"
5. Click on the "add" button and try to find a news record

Expected: You should see 1 or more records
Current: The error " Server request failed" is shown


Alternative way:

```
http://decoy.local:8888/admin/articles/autocomplete?query=te&parent_id=1&parent_controller=App%5CHttp%5CControllers%5CAdmin%5CTags
```

Just replace the url ;)

Hope that helps.