### PR TITLE
Pivot Position Sorting

### DIFF
--- a/classes/Input/Position.php
+++ b/classes/Input/Position.php
@@ -25,7 +25,7 @@ class Position
         if ($relationship && Request::has('parent_id')) {
             $relation = $this->item->{$relationship}();
             if ($relation instanceof BelongsToMany) {
-                $this->pivot = $relation->where($relation->getOtherKey(), '=', request('parent_id'))->first()->pivot;
+                $this->pivot = $relation->where($relation->first()->pivot->getOtherKey(), '=', request('parent_id'))->first()->pivot;
             }
         }
     }


### PR DESCRIPTION
issue #73 

getOtherKey was moved onto the Pivot Object in Laravel 5.4; by fetching the first Result we can directly access it. (in the position class there should always be a ->first() element)

